### PR TITLE
update libccv link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 ![](https://farm8.staticflickr.com/7415/16250786748_f0e3984e19_o.png)
 
-This is an addon for openFrameworks that wraps the computer vision library [libccv](libccv.org). The goal is to experiment with a few features that distinguish libccv from OpenCv, like the deep convolutional neural net implementation. ofxCcv may be merged with ofxCv to provide as much power as possible in a single addon without requiring developers to keep track of which library they are using.
+This is an addon for openFrameworks that wraps the computer vision library [libccv](http://libccv.org). The goal is to experiment with a few features that distinguish libccv from OpenCv, like the deep convolutional neural net implementation. ofxCcv may be merged with ofxCv to provide as much power as possible in a single addon without requiring developers to keep track of which library they are using.
 
 Before you can use this addon to classify images, you will need to either run `./download-classifier.sh`, or get the files manually by downloading [libccv](http://libccv.org/) and copying `image-net-2012.sqlite3` and `image-net-2012.words` from `ccv/samples` into `openFrameworks/addons/ofxCcv/example/bin/data/`.
 


### PR DESCRIPTION
missing `http://` from the link was causing it to open relative to this repo.
