### PR TITLE
Fix memory leaks, add const corrections, initialize variables.

### DIFF
--- a/src/ofxCcv.cpp
+++ b/src/ofxCcv.cpp
@@ -133,7 +133,7 @@ vector<float> ofxCcv::encode(const ofPixels& pix, int layer) {
     ccv_dense_matrix_t* input = 0;
     ccv_size_t size = ccv_size(225, 225);   // size of the default net, this may need to be changed
     ccv_convnet_input_formation(size, &image, &input);
-    ccv_dense_matrix_t* b = 0;
+    ccv_dense_matrix_t* b = nullptr;
     ccv_convnet_encode(convnet, &input, &b, 1);
     int numChannels = CCV_GET_CHANNEL(b->type);
     int numElements = b->rows * b->cols * numChannels;

--- a/src/ofxCcv.cpp
+++ b/src/ofxCcv.cpp
@@ -24,7 +24,7 @@ ofxCcv::~ofxCcv() {
     ccv_drain_cache();
 }
     
-void ofxCcv::setup(string network) {
+void ofxCcv::setup(const std::string& network) {
     string imagenetFilename = ofToDataPath(network);
     loaded = ofFile::doesFileExist(ofToDataPath(network));
     if (!loaded) {
@@ -51,12 +51,12 @@ void ofxCcv::setup(string network) {
     }
 }
 
-void ofxCcv::setupFace(string network) {
+void ofxCcv::setupFace(const std::string& network) {
     string imagenetFilename = ofToDataPath(network);
     cascade = ccv_scd_classifier_cascade_read(imagenetFilename.c_str());
 }
 
-void ofxCcv::setupPedestrians(string network){
+void ofxCcv::setupPedestrians(const std::string& network){
     string imagenetFilename = ofToDataPath(network);
     cascadePedestrians = ccv_icf_read_classifier_cascade(imagenetFilename.c_str());
 }
@@ -122,7 +122,7 @@ vector<ofImage> ofxCcv::getWeights() {
     return weightImgs;
 }
 
-vector<float> ofxCcv::encode(ofPixels & img, int layer) {
+vector<float> ofxCcv::encode(const ofPixels& pix, int layer) {
     convnet->count = layer; // hack to extract a particular layer with encode
     vector<float> data;
     ofImage imgCopy;

--- a/src/ofxCcv.h
+++ b/src/ofxCcv.h
@@ -18,11 +18,10 @@ private:
     bool loaded = false;
     
     //needed for face detection
-    ccv_dense_matrix_t image;
-    ccv_scd_classifier_cascade_t* cascade = nullptr;
+    mutable ccv_scd_classifier_cascade_t* cascade = nullptr;
     
     //needed for pedestrian detection
-    ccv_icf_classifier_cascade_t* cascadePedestrians = nullptr;
+    mutable ccv_icf_classifier_cascade_t* cascadePedestrians = nullptr;
     
 public:
     class Classification {
@@ -44,30 +43,34 @@ public:
         
     ofxCcv();
     ~ofxCcv();
-    void setup(const std::string& network);
+    void setup(const std::string& network, const std::string& labels = "image-net-2012.words");
     void setupFace(const std::string& network);
     void setupPedestrians(const std::string& network);
     
-    bool isLoaded() {return loaded;}
+    bool isLoaded() const {return loaded;}
+    int numLayers() const {return nLayers;}
+    const vector<string>& getLayerNames() const {return layerNames;}
+    vector<ofxCcv::FeatureMap> getFeatureMaps(int layer) const;
+    vector<ofImage> getWeights() const;
+    const vector<string>& getClasses() const {return words;}
     
-    int numLayers() {return nLayers;}
-    vector<string> & getLayerNames() {return layerNames;}
-    vector<ofxCcv::FeatureMap> getFeatureMaps(int layer);
-    vector<ofImage> getWeights();
-    vector<string> & getClasses() {return words;}
-    
-    vector<float> encode(const ofPixels& img, int layer);
-    vector<float> encode(const ofBaseHasPixels& img, int layer) {return encode(img.getPixels(), layer);}
+    vector<float> encode(const ofPixels& img, int layer) const;
+    vector<float> encode(const ofBaseHasPixels& img, int layer) const {return encode(img.getPixels(), layer);}
     
     template <class T>
-    vector<Classification> classify(const T& img, int maxResults = 5) {
+    vector<Classification> classify(const T& img, int maxResults = 5) const {
         vector<Classification> results;
         ccv_dense_matrix_t image;
         image = toCcv(img);
+        
         ccv_dense_matrix_t* input = nullptr;
+        
         ccv_convnet_input_formation(convnet->input, &image, &input);
-        ccv_array_t* rank = 0;
+        
+        ccv_array_t* rank = nullptr;
+
         ccv_convnet_classify(convnet, &input, 1, &rank, maxResults, 1);
+        
         for (int i = 0; i < rank->rnum; i++) {
             ccv_classification_t* classification = (ccv_classification_t*)ccv_array_get(rank, i);
             Classification result;
@@ -79,15 +82,16 @@ public:
         }
         ccv_array_free(rank);
         ccv_matrix_free(input);
+        
         return results;
     }
     
     template <class TT>
-    vector<ofRectangle> classifyFace(const TT& img) {
+    vector<ofRectangle> classifyFace(const TT& img) const {
         
         vector<ofRectangle> results;
-
-         image = toCcv(img);
+    
+        ccv_dense_matrix_t image = toCcv(img);
         
         ccv_array_t* faces = ccv_scd_detect_objects(&image, &cascade, 1, ccv_scd_default_params);
         
@@ -95,34 +99,29 @@ public:
         {
             ccv_comp_t* face = (ccv_comp_t*)ccv_array_get(faces, i);
             results.push_back(ofRectangle(face->rect.x, face->rect.y, face->rect.width, face->rect.height));
-//            printf("%d %d %d %d\n", face->rect.x, face->rect.y, face->rect.width, face->rect.height);
         }
+        
         ccv_array_free(faces);
         return results;
     }
     
     template <class TTT>
-    vector<ofRectangle> classifyPedestrians(const TTT& img) {
+    vector<ofRectangle> classifyPedestrians(const TTT& img) const {
         
         vector<ofRectangle> results;
 
-        image = toCcv(img);
+        ccv_dense_matrix_t image = toCcv(img);
         
-        unsigned int elapsed_time = ofGetElapsedTimeMillis(); // get_current_time();
         ccv_array_t* seq = ccv_icf_detect_objects(&image, &cascadePedestrians, 1, ccv_icf_default_params);
-        elapsed_time = ofGetElapsedTimeMillis() - elapsed_time;
     
-        int i;
-        for (i = 0; i < seq->rnum; i++)
+        for (int i = 0; i < seq->rnum; i++)
         {
             ccv_comp_t* comp = (ccv_comp_t*)ccv_array_get(seq, i);
             results.push_back(ofRectangle(comp->rect.x, comp->rect.y, comp->rect.width, comp->rect.height));
-//            printf("%d %d %d %d %f\n", comp->rect.x, comp->rect.y, comp->rect.width, comp->rect.height, comp->classification.confidence);
         }
-//        printf("total : %d in time %dms\n", seq->rnum, elapsed_time);
+
         ccv_array_free(seq);
         
-
         return results;
     }
 };

--- a/src/ofxCcv.h
+++ b/src/ofxCcv.h
@@ -11,18 +11,18 @@ ccv_dense_matrix_t toCcv(const ofBaseHasPixels& pix);
 
 class ofxCcv {
 private:
-    ccv_convnet_t* convnet;
+    ccv_convnet_t* convnet = nullptr;
     vector<string> words;
-    int nLayers;
+    int nLayers = 0;
     vector<string> layerNames;
-    bool loaded;
+    bool loaded = false;
     
     //needed for face detection
     ccv_dense_matrix_t image;
-    ccv_scd_classifier_cascade_t* cascade;
+    ccv_scd_classifier_cascade_t* cascade = nullptr;
     
     //needed for pedestrian detection
-    ccv_icf_classifier_cascade_t* cascadePedestrians;
+    ccv_icf_classifier_cascade_t* cascadePedestrians = nullptr;
     
 public:
     
@@ -65,7 +65,7 @@ public:
         vector<Classification> results;
         ccv_dense_matrix_t image;
         image = toCcv(img);
-        ccv_dense_matrix_t* input = 0;
+        ccv_dense_matrix_t* input = nullptr;
         ccv_convnet_input_formation(convnet->input, &image, &input);
         ccv_array_t* rank = 0;
         ccv_convnet_classify(convnet, &input, 1, &rank, maxResults, 1);

--- a/src/ofxCcv.h
+++ b/src/ofxCcv.h
@@ -25,7 +25,6 @@ private:
     ccv_icf_classifier_cascade_t* cascadePedestrians = nullptr;
     
 public:
-    
     class Classification {
     public:
         int imageNetId;
@@ -69,8 +68,7 @@ public:
         ccv_convnet_input_formation(convnet->input, &image, &input);
         ccv_array_t* rank = 0;
         ccv_convnet_classify(convnet, &input, 1, &rank, maxResults, 1);
-        int i;
-        for (i = 0; i < rank->rnum; i++) {
+        for (int i = 0; i < rank->rnum; i++) {
             ccv_classification_t* classification = (ccv_classification_t*)ccv_array_get(rank, i);
             Classification result;
             result.imageNetId = classification->id + 1;
@@ -92,8 +90,8 @@ public:
          image = toCcv(img);
         
         ccv_array_t* faces = ccv_scd_detect_objects(&image, &cascade, 1, ccv_scd_default_params);
-        int i;
-        for (i = 0; i < faces->rnum; i++)
+        
+        for (int i = 0; i < faces->rnum; i++)
         {
             ccv_comp_t* face = (ccv_comp_t*)ccv_array_get(faces, i);
             results.push_back(ofRectangle(face->rect.x, face->rect.y, face->rect.width, face->rect.height));

--- a/src/ofxCcv.h
+++ b/src/ofxCcv.h
@@ -45,9 +45,9 @@ public:
         
     ofxCcv();
     ~ofxCcv();
-    void setup(string network);
-    void setupFace(string network);
-    void setupPedestrians(string network);
+    void setup(const std::string& network);
+    void setupFace(const std::string& network);
+    void setupPedestrians(const std::string& network);
     
     bool isLoaded() {return loaded;}
     
@@ -57,8 +57,8 @@ public:
     vector<ofImage> getWeights();
     vector<string> & getClasses() {return words;}
     
-    vector<float> encode(ofPixels & img, int layer);
-    vector<float> encode(ofBaseHasPixels & img, int layer) {return encode(img.getPixels(), layer);}
+    vector<float> encode(const ofPixels& img, int layer);
+    vector<float> encode(const ofBaseHasPixels& img, int layer) {return encode(img.getPixels(), layer);}
     
     template <class T>
     vector<Classification> classify(const T& img, int maxResults = 5) {


### PR DESCRIPTION
- When running `encode`, the two allocated matrices were never freed.  
- When destroying the `ofxCcv` object, the pedestrian / face cascades were not freed.
- When reloading a model or a classifier using setup, existing models / classifiers were not freed.
- If `ofxCcv` was allocated, but never setup, the destructor would fail, because the cascade pointers were never initialized making them appear allocated when they weren't.
